### PR TITLE
Cache user data in browser

### DIFF
--- a/gpa-calculator.js
+++ b/gpa-calculator.js
@@ -14,21 +14,42 @@ app.controller('calculator', function(){
   this.grades = { };
   this.gpa = 0;
 
-  // copy GRADES object
-  for (grade in GRADES) {
-    this.grades[grade] = GRADES[grade];
-  }
-  // init subjects grades
-  for(var i = 0; i < that.years.length; i++) {
-    var year = that.years[i];
-    for(var j = 0; j < year.length; j++) {
-      var semester = year[j];
-      for(var k = 0; k < semester.subjects.length; k++) {
-        var subject = semester.subjects[k];
-        subject.grade = 'Distinction';
+  this.initializeGrades = function (localGrades) {
+    // Checks if grades exist in local storage.
+    if(localGrades != null) {
+      // Use value initialized in local storage.
+      this.grades = JSON.parse(localGrades);
+    } else {
+      // copy GRADES object
+      for (grade in GRADES) {
+        this.grades[grade] = GRADES[grade];
       }
     }
-  }
+  };
+
+  this.initializeYears = function (localYears) {
+    // Checks if year configuration exists in local storage.
+    if(localYears != null) {
+      // Use value initialized in local storage.
+      that.years = JSON.parse(localYears);
+    } else {
+      // init subjects grades
+      for(var i = 0; i < that.years.length; i++) {
+        var year = that.years[i];
+        for(var j = 0; j < year.length; j++) {
+          var semester = year[j];
+          semester.enabled = false;
+          for(var k = 0; k < semester.subjects.length; k++) {
+            var subject = semester.subjects[k];
+            subject.grade = 'Distinction';
+          }
+        }
+      }
+    }
+  };
+
+  this.initializeGrades(localStorage.grades);
+  this.initializeYears(localStorage.years);
 
   var yearsName = [['Preparatory', 'Prep'], ['First', '1st'], ['Second', '2nd'],
                    ['Third', '3rd'], ['Fourth', '4th']];
@@ -63,8 +84,13 @@ app.controller('calculator', function(){
   	} else {
       that.gpa = 0;
     }
+
+    localStorage.years = JSON.stringify(that.years);
+    localStorage.grades = JSON.stringify(that.grades);
   };
 
+  // Use to calculate the GPA when the page loads initially with certain local storage data.
+  this.calculateGPA();
 });
 
 var GRADES = {

--- a/index.html
+++ b/index.html
@@ -56,11 +56,15 @@
           <div class="panel-group" id="accordion">
 
             <div class="panel panel-default">
-              <div class="panel-heading" data-toggle="collapse" data-parent="#accordion" href="#settings">
+              <div class="panel-heading">
                 <h4 class="panel-title">
                   <span class="fa fa-cog"></span>
-                  <a>GPA Settings</a>
+                  <a data-toggle="collapse" data-parent="#accordion" href="#settings">GPA Settings</a>
                 </h4>
+                <div class="btn-group pull-right">
+                  <button type="button" ng-click="calc.initializeGrades(); calc.calculateGPA()" class="btn btn-secondary btn-sm">Reset</button>
+                </div>
+                <div class="clearfix"></div>
               </div>
               <div id="settings" class="panel-collapse collapse">
                 <div class="panel-body">
@@ -71,7 +75,7 @@
                         <a href="http://egyptscholars.org/study-abroad-guide/">Study Abroad Guide</a> section#4 and their <a href="https://youtu.be/2KvOnWH-Scs?t=10m37s"> video </a>. You can adjust the points according to your needs.
                       </p>
                     </div>
-      
+
                     <form class="form-horizontal">
                       <fieldset>
                         <div class="form-group">
@@ -97,10 +101,16 @@
                     Total GPA
                   </a>
                 </h4>
+                <div class="btn-group pull-right">
+                  <button type="button" ng-click="calc.initializeYears(); calc.calculateGPA()" class="btn btn-secondary btn-sm">Reset</button>
+                </div>
+                <div class="clearfix"></div>
               </div>
-              <div class="panel-body"> <h4>{{ calc.gpa | number}} </h4> </div>
+              <div class="panel-body">
+                <h4>{{ calc.gpa | number}} </h4>
+              </div>
             </div>
-            
+
             <div class="panel panel-success" ng-repeat-start="year in calc.years" >
               <div class="panel-heading">
                 <div class="panel-title">
@@ -108,7 +118,7 @@
                       {{ calc.getYearName($index) }} Year - 1st Semester
                   </a>
                   <label class="switch pull-right">
-                    <input type="checkbox" ng-click="year[0].enabled=!year[0].enabled; calc.calculateGPA()">
+                    <input type="checkbox" ng-model="year[0].enabled" ng-click="calc.calculateGPA()">
                     <span class="slider round"></span>
                   </label>
                 </div>
@@ -148,7 +158,7 @@
                         {{ calc.getYearName($index) }} Year - 2nd Semester
                     </a>
                     <label class="switch pull-right">
-                      <input type="checkbox"  ng-click="year[1].enabled=!year[1].enabled; calc.calculateGPA()">
+                      <input type="checkbox"  ng-model="year[1].enabled" ng-click="calc.calculateGPA()">
                       <span class="slider round"></span>
                     </label>
                   </div>


### PR DESCRIPTION
The implementation embedded in this commit checks `localStorage` for any previous data whether for the grades or years so that it can be loaded initially.

In case there doesn't exist any data the default is loaded.
Reset buttons were added to the Heading of the two panels (GPA Settings and GPA).

The collapse action of the GPA settings panel was modified so that it doesn't collapse in case of pressing reset button.

This is the current UI after the addition of reset buttons.

![screenshot from 2018-02-27 13-43-59](https://user-images.githubusercontent.com/10701007/36726999-524d11e4-1bc4-11e8-85bb-6864aa027a2a.png)

fixes #2 